### PR TITLE
Remove extra whitespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,30 +5,30 @@
   <meta charset="utf-8">
   <link href="min/wmin.css" type="text/css" rel="stylesheet">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title> Wireframes made easy </title>
+  <title>Wireframes made easy</title>
 </head>
 
 <body>
 
   <div class="container nav end noborder">
     <span class="child logo" data-balloon="Logo!" data-balloon-pos="down">LALALALA</span>
-    <span class=" padd " data-balloon="Some link " data-balloon-pos="down">Nav1dsad</span>
-    <span class="padd" data-balloon="Eg. Home" data-balloon-pos="up">Nav2 might contain </span>
-    <span class=" padd " data-balloon="About Us! " data-balloon-pos="down">Contact us </span>
-    <span class="padd" data-balloon="Contact Us" data-balloon-pos="up">Contact us </span>
+    <span class="padd" data-balloon="Some link" data-balloon-pos="down">Nav1dsad</span>
+    <span class="padd" data-balloon="Eg. Home" data-balloon-pos="up">Nav2 might contain</span>
+    <span class="padd" data-balloon="About Us!" data-balloon-pos="down">Contact us</span>
+    <span class="padd" data-balloon="Contact Us" data-balloon-pos="up">Contact us</span>
   </div>
 
-  <div class=" parent header" data-balloon-pos="down" data-balloon="Some long description telling about Header Image"></div>
+  <div class="parent header" data-balloon-pos="down" data-balloon="Some long description telling about Header Image"></div>
 
-  <div class="container noborder products ">
-    <div class="parent box4 v-end ">asdasdf asdsad asdasdf
+  <div class="container noborder products">
+    <div class="parent box4 v-end">asdasdf asdsad asdasdf
       <br>asdasdf asdsad asdasdfasdasdf asdsad asdasdf</div>
-    <div class="parent box4 v-end ">asdasdf asdsad asdasdf
+    <div class="parent box4 v-end">asdasdf asdsad asdasdf
       <br>asdasdf asdsad g asdasdasdf asdsad g asdasdas asdasdf
       <br>asdasdf asdsad gg asdasdas asdasdf</div>
-    <div class="parent box4 v-end ">asdasdf asdsad asdasdf
+    <div class="parent box4 v-end">asdasdf asdsad asdasdf
       <br>asdasdf asdsad asdasdfasdasdf asdsad asdasdf</div>
-    <div class="parent box4 v-end ">asdasdf asdsad asdasdf
+    <div class="parent box4 v-end">asdasdf asdsad asdasdf
       <br>asdasdf asdsad asdasdfasdasdf asdsad g pasdasdf asdsad g asdasdf asdsad g asdasdleasure</div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
   <div class="container nav end noborder">
     <span class="child logo" data-balloon="Logo!" data-balloon-pos="down">LALALALA</span>
     <span class="padd" data-balloon="Some link" data-balloon-pos="down">Nav1dsad</span>
-    <span class="padd" data-balloon="Eg. Home" data-balloon-pos="up">Nav2 might contain</span>
-    <span class="padd" data-balloon="About Us!" data-balloon-pos="down">Contact us</span>
-    <span class="padd" data-balloon="Contact Us" data-balloon-pos="up">Contact us</span>
+    <span class="padd" data-balloon="E.g. Home" data-balloon-pos="up">Nav2 might contain</span>
+    <span class="padd" data-balloon="About Us!" data-balloon-pos="down">About Us!</span>
+    <span class="padd" data-balloon="Contact Us" data-balloon-pos="up">Contact Us</span>
   </div>
 
   <div class="parent header" data-balloon-pos="down" data-balloon="Some long description telling about Header Image"></div>
@@ -36,7 +36,7 @@
     <span>The good old Search Bar!sadasdasdsa dasdasdasdadasd<br>
       The good old Search Bar!sadasdasdsa dasdasdasdadasd.asdasdasdasdasdasdassssssssssssssdadasdasd</span>
     <form>
-      <input type="text"></input>
+      <input type="text"/>
       <button>Submit</button>
     </form>
   </div>


### PR DESCRIPTION
To keep a consistent "coding style" across the page

Also, having no documentation of this framework, this demo should serve as a guide and avoid possible misunderstandings.  
(For instance, when I checked the demo's markup, at first I thought that the whitespace surrounding `padd` might be serving some purpose -- changing padding (right or left) depending on the presence of whitespace (right or left) next to `padd`...)